### PR TITLE
Add humorous cybersecurity script samples in Scala

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+# Python artifacts
+__pycache__/
+*.pyc
+
+# Scala artifacts
+target/
+*.class

--- a/README.md
+++ b/README.md
@@ -1,3 +1,14 @@
 # Security
 
-# This is a sample file
+Sample Scala scripts demonstrating cybersecurity concepts from beginner to advanced levels.
+Each example uses an ``advanced insult`` generator to add levity while learning.
+
+## Scripts
+
+- `scripts/Insult.scala` – Shared utility generating humorous insults.
+- `scripts/BeginnerPortScan.scala` – Basic port scanner showing socket usage.
+- `scripts/IntermediateBruteForce.scala` – Simulated password brute-force tool using in-memory wordlist.
+- `scripts/AdvancedSniffer.scala` – Packet sniffer that invokes `tcpdump` and decorates output.
+
+These scripts are for educational purposes only. Always obtain proper authorization
+before running security tools against any system.

--- a/scripts/AdvancedSniffer.scala
+++ b/scripts/AdvancedSniffer.scala
@@ -1,0 +1,17 @@
+import scala.sys.process._
+import scala.util.Try
+
+object AdvancedSniffer {
+  def main(args: Array[String]): Unit = {
+    val cmd = Seq("tcpdump", "-l", "-n", "-c", "5")
+    println("Starting tcpdump...")
+
+    val result = Try {
+      cmd.lineStream.foreach(line => println(s"$line -- ${Insult.generate()}"))
+    }
+
+    result.failed.foreach { _ =>
+      println("tcpdump failed to run. Install it or run with sufficient privileges.")
+    }
+  }
+}

--- a/scripts/BeginnerPortScan.scala
+++ b/scripts/BeginnerPortScan.scala
@@ -1,0 +1,19 @@
+import java.net.{InetSocketAddress, Socket}
+import scala.util.Try
+
+object BeginnerPortScan {
+  def main(args: Array[String]): Unit = {
+    val host = if (args.nonEmpty) args(0) else "localhost"
+    val ports = 1 to 1024
+
+    println(s"Scanning $host...")
+    for (port <- ports) {
+      Try {
+        val socket = new Socket()
+        socket.connect(new InetSocketAddress(host, port), 200)
+        socket.close()
+        println(s"Port $port open, ${Insult.generate()}!")
+      }
+    }
+  }
+}

--- a/scripts/Insult.scala
+++ b/scripts/Insult.scala
@@ -1,0 +1,29 @@
+import scala.util.Random
+
+object Insult {
+  private val adjectives = Vector(
+    "clueless",
+    "pathetic",
+    "inept",
+    "bungling",
+    "witless",
+    "gullible"
+  )
+
+  private val nouns = Vector(
+    "script-kiddie",
+    "newbie",
+    "luser",
+    "greenhorn",
+    "rookie",
+    "buffoon"
+  )
+
+  private val rng = new Random()
+
+  def generate(): String = {
+    val adj = adjectives(rng.nextInt(adjectives.length))
+    val noun = nouns(rng.nextInt(nouns.length))
+    s"$adj $noun"
+  }
+}

--- a/scripts/IntermediateBruteForce.scala
+++ b/scripts/IntermediateBruteForce.scala
@@ -1,0 +1,15 @@
+object IntermediateBruteForce {
+  def main(args: Array[String]): Unit = {
+    val target = "hunter2"
+    val guesses = List("123456", "password", "letmein", "hunter2", "trustno1")
+
+    for (guess <- guesses) {
+      if (guess == target) {
+        println(s"Password cracked: '$guess', ${Insult.generate()}!")
+        return
+      } else {
+        println(s"Tried '$guess' - no luck, ${Insult.generate()}!")
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- port insult generator and sample cybersecurity scripts to Scala
- document Scala versions of the beginner port scanner, intermediate brute force demo, and advanced sniffer
- ignore Scala build artifacts in version control

## Testing
- `scalac scripts/*.scala` *(fails: command not found)*
- `apt-get install -y scala` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_6896110f8ca88332a4e561ddd62ec6af